### PR TITLE
Fix the name used in the javascript to use the sanitized version.

### DIFF
--- a/resources/leiningen/new/ajom/src__dev__build.clj
+++ b/resources/leiningen/new/ajom/src__dev__build.clj
@@ -7,7 +7,7 @@
 (defn- plugin-setup []
   (-> (cljs/init-state)
       (cljs/set-build-options
-          {:node-global-prefix "global.{{raw-name}}"})
+          {:node-global-prefix "global.{{sanitized}}"})
       (cljs/find-resources-in-classpath)
       (umd/create-module
         {:activate '{{raw-name}}.core/activate


### PR DESCRIPTION
This will prevent projects with illegal javascript character in their name to crash.

`my-project` is an example of project name that was not working before the fix.

Signed-off-by: Marc-Antoine Sauve madeinqchw@gmail.com
